### PR TITLE
bpo-26180: Fix multiple registration of ForkAwareLocal atfork cleaner

### DIFF
--- a/Lib/multiprocessing/util.py
+++ b/Lib/multiprocessing/util.py
@@ -348,8 +348,11 @@ class ForkAwareThreadLock(object):
 
 
 class ForkAwareLocal(threading.local):
-    def __init__(self):
-        register_after_fork(self, lambda obj : obj.__dict__.clear())
+    def __new__(cls):
+        self = threading.local.__new__(cls)
+        register_after_fork(self, lambda obj: obj.__dict__.clear())
+        return self
+
     def __reduce__(self):
         return type(self), ()
 

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -4599,6 +4599,27 @@ class TestForkAwareThreadLock(unittest.TestCase):
         self.assertLessEqual(new_size, old_size)
 
 #
+# Issue #26180: ForkAwareLocal
+#
+
+class TestForkAwareLocal(unittest.TestCase):
+    # Issue #26180 meant that with each new thread using an instance of
+    # ForkAwareLocal, fork registry would get a duplicate entry for that
+    # instance.
+
+    def test_registry_after_thread_spawn(self):
+        v = util.ForkAwareLocal()
+        # v cleanup handler is now registered.
+        old_size = len(util._afterfork_registry)
+        # Setting an attr on v from a new thread will call v.__init__.
+        t = threading.Thread(target=setattr, args=(v, 'x', 0))
+        t.start()
+        t.join()
+        # Ensure that v.__init__ did not register a new handler.
+        new_size = len(util._afterfork_registry)
+        self.assertEqual(new_size, old_size)
+
+#
 # Check that non-forked child processes do not inherit unneeded fds/handles
 #
 

--- a/Misc/NEWS.d/next/Library/2019-06-11-22-58-11.bpo-26180.yXZmdk.rst
+++ b/Misc/NEWS.d/next/Library/2019-06-11-22-58-11.bpo-26180.yXZmdk.rst
@@ -1,0 +1,2 @@
+Fixed memory leak in :class:`multiprocessing.util.ForkAwareLocal` when used
+by multiple threads.


### PR DESCRIPTION
`threading.local` instance `__init__` method is called multiple times, once per
thread where the instance is used, but ForkAwareLocal atfork handler needs to be
registered just once when its instance is created. If it is registered many
times, the registrations bloat `_afterfork_registry` as long as the instance is
alive, and can exhaust all memory.